### PR TITLE
[fix]: line & column parameters

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,9 @@
 identifier_name:
   allowed_symbols: ['_']
 
+large_tuple:
+  warning: 5
+
 excluded:
   - .build
   - .git

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 ## Installation
 
+### Download
+
+Download the universal binary from the latest release, extract the zip and move it to `/usr/local/bin/`.
+
 ### Build locally
 
 ```sh

--- a/Sources/CodeEditCLI/Open.swift
+++ b/Sources/CodeEditCLI/Open.swift
@@ -56,20 +56,31 @@ extension CodeEditCLI {
         }
 
         private func extractLineColumn(_ path: String) throws -> (path: String, line: Int?, column: Int?) {
-            let components = path.split(separator: ":")
-            let path = String(components[0])
 
+            // split the string at `:` to get line and column numbers
+            let components = path.split(separator: ":")
+
+            // set path to only the first component
+            guard let first = components.first else {
+                throw CLIError.invalidFileURL
+            }
+            let path = String(first)
+
+            // switch on the number of components
             switch components.count {
-            case 1:
+            case 1: // no line or column number provided
                 return (path, nil, nil)
-            case 2:
+
+            case 2: // only line number provided
                 guard let row = Int(components[1]) else { throw CLIError.invalidFileURL }
                 return (path, row, nil)
-            case (3...):
+
+            case 3: // line and column number provided
                 guard let row = Int(components[1]),
                       let column = Int(components[2]) else { throw CLIError.invalidFileURL }
                 return (path, row, column)
-            default:
+
+            default: // any other case throw an error since this is invalid
                 throw CLIError.invalidFileURL
             }
         }

--- a/Sources/CodeEditCLI/main.swift
+++ b/Sources/CodeEditCLI/main.swift
@@ -11,7 +11,7 @@ import Foundation
 // ##################################################
 //  This needs to be changed prior to every release!
 // ##################################################
-let CLI_VERSION = "0.0.3"
+let CLI_VERSION = "0.0.5"
 
 struct CodeEditCLI: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/CodeEditCLI/main.swift
+++ b/Sources/CodeEditCLI/main.swift
@@ -30,6 +30,7 @@ struct CodeEditCLI: ParsableCommand {
 
     enum CLIError: Error {
         case invalidWorkingDirectory
+        case invalidFileURL
     }
 }
 


### PR DESCRIPTION
As proposed in #16 the syntax to open a file at specified line and column has changed:

```sh
# Prior
codeedit-cli index.html -l 42 -c 4

# New
codeedit-cli index.html:42:4
```