### PR TITLE
[feat]: Makefile, rename to `codeedit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+prefix ?= /usr/local
+bindir = $(prefix)/bin
+binname = "codeedit"
+
+build:
+	swift build -c release --disable-sandbox
+
+install: build
+	install -d "$(bindir)"
+	install ".build/release/$(binname)" "$(bindir)"
+
+uninstall:
+	rm -rf "$(bindir)/$(binname)"
+
+clean:
+	rm -rf .build
+
+.PHONY: build install uninstall clean

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "CodeEditCLI",
     products: [
-        .executable(name: "codeedit-cli", targets: ["CodeEditCLI"])
+        .executable(name: "codeedit", targets: ["CodeEditCLI"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0")

--- a/Sources/CodeEditCLI/Version.swift
+++ b/Sources/CodeEditCLI/Version.swift
@@ -35,20 +35,6 @@ extension CodeEditCLI {
             }
         }
 
-        private func codeEditURLData() throws -> Data {
-            let task = Process()
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.launchPath = "/usr/bin/osascript"
-
-            task.arguments = ["-e"]
-            task.arguments?.append("POSIX path of (path to application \"CodeEdit\")")
-
-            try task.run()
-
-            return pipe.fileHandleForReading.readDataToEndOfFile()
-        }
-
         private func infoPlistUrl(_ url: URL?) -> URL? {
             if let url = url?.appendingPathComponent("Contents")
                              .appendingPathComponent("Info.plist") {

--- a/Sources/CodeEditCLI/Version.swift
+++ b/Sources/CodeEditCLI/Version.swift
@@ -16,23 +16,23 @@ extension CodeEditCLI {
         )
 
         func run() throws {
-            // Run an apple script to find CodeEdit.app
-            let pathData = try codeEditURLData()
+            // Print the cli version
+            print("CodeEditCLI: \t\(CLI_VERSION)")
+
+            // File URL of CodeEdit.app
+            let appURL = URL(fileURLWithPath: "/Applications/CodeEdit.app")
 
             // Check if there is an Info.plist inside CodeEdit.app
             // Then get the version number and print it out
             //
             // This will fail when CodeEdit.app is not installed
-            if let url = infoPlistUrl(pathData: pathData),
+            if let url = infoPlistUrl(appURL),
                let plist = NSDictionary(contentsOf: url) as? [String: Any],
                let version = plist["CFBundleShortVersionString"] as? String {
                 print("CodeEdit.app: \t\(version)")
             } else {
                 print("CodeEdit.app is not installed.")
             }
-
-            // Print the cli version
-            print("CodeEditCLI: \t\(CLI_VERSION)")
         }
 
         private func codeEditURLData() throws -> Data {
@@ -49,11 +49,9 @@ extension CodeEditCLI {
             return pipe.fileHandleForReading.readDataToEndOfFile()
         }
 
-        private func infoPlistUrl(pathData: Data) -> URL? {
-            if let path = String(data: pathData, encoding: .utf8) {
-                let url = URL(fileURLWithPath: path.trimmingCharacters(in: .whitespacesAndNewlines))
-                    .appendingPathComponent("Contents")
-                    .appendingPathComponent("Info.plist")
+        private func infoPlistUrl(_ url: URL?) -> URL? {
+            if let url = url?.appendingPathComponent("Contents")
+                             .appendingPathComponent("Info.plist") {
                 return url
             } else {
                 return nil


### PR DESCRIPTION
- rename executable to `codeedit`.
- fix the version command.
- add Makefile in preparation for `Homebrew` formula.