### PR TITLE
[feat]: add terse option for version command

### DIFF
--- a/Sources/CodeEditCLI/Version.swift
+++ b/Sources/CodeEditCLI/Version.swift
@@ -15,7 +15,16 @@ extension CodeEditCLI {
             abstract: "Prints the version of the CLI and CodeEdit.app."
         )
 
+        @Flag(name: .shortAndLong, help: "Only prints the version number of the CLI")
+        var terse = false
+
         func run() throws {
+            // if terse flag is set only print the cli version number
+            if terse {
+                print(CLI_VERSION)
+                return
+            }
+
             // Print the cli version
             print("CodeEditCLI: \t\(CLI_VERSION)")
 

--- a/Sources/CodeEditCLI/main.swift
+++ b/Sources/CodeEditCLI/main.swift
@@ -11,7 +11,7 @@ import Foundation
 // ##################################################
 //  This needs to be changed prior to every release!
 // ##################################################
-let CLI_VERSION = "0.0.8"
+let CLI_VERSION = "0.0.9"
 
 struct CodeEditCLI: ParsableCommand {
     static let configuration = CommandConfiguration(


### PR DESCRIPTION
e.g.:

```bash
codeedit version --terse
# or
codeedit version -t 
# will output: 
0.0.8
```

in comparison:

```bash
codeedit version
# will output:
CodeEditCLI: 	0.0.8
CodeEdit.app: 	0.0.1
```