### PR TITLE
Added option to create new instance

### DIFF
--- a/Sources/CodeEditCLI/Open.swift
+++ b/Sources/CodeEditCLI/Open.swift
@@ -15,6 +15,9 @@ extension CodeEditCLI {
             abstract: "A command-line tool to open files/folders in CodeEdit.app."
         )
 
+        @Flag(name: .shortAndLong, help: "Open the editor in a new instance.")
+        private var newWindow = false
+        
         @Argument(
             help: """
             The path of a file/folder to open.
@@ -30,6 +33,7 @@ extension CodeEditCLI {
             // use the `open` cli as the executable
             task.launchPath = "/usr/bin/open"
 
+            
             if let path {
                 let (path, line, column) = try extractLineColumn(path)
                 let openURL = try absolutePath(path, for: task)
@@ -43,7 +47,11 @@ extension CodeEditCLI {
             } else {
                 task.arguments = ["-a", "CodeEdit.app"]
             }
-
+            
+            if newWindow {
+                task.arguments?.append("-n")
+            }
+            
             try task.run()
         }
 


### PR DESCRIPTION
This adds the option to open CodeEdit in a new instance, potentially solving #4. It uses the `open -n` flag to create a new instance.

Unfortunately, I was not able to found a way to open it in a new window, using either `applescript` or `open`. It does mean that multiple icons will appear in the dock.