### PR TITLE
Ensure Folder Existence; Create Missing Parent Folders as Needed

### DIFF
--- a/Sources/CodeEditCLI/Open.swift
+++ b/Sources/CodeEditCLI/Open.swift
@@ -38,7 +38,11 @@ extension CodeEditCLI {
                 // Create directories if they don't exist
                 let directoryURL = openURL.deletingLastPathComponent()
                 do {
-                    try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
+                    try fileManager.createDirectory(
+                        at: directoryURL,
+                        withIntermediateDirectories: true,
+                        attributes: nil
+                    )
                 } catch {
                     print("Failed to create directory at \(directoryURL.path): \(error)")
                     return

--- a/Sources/CodeEditCLI/main.swift
+++ b/Sources/CodeEditCLI/main.swift
@@ -26,8 +26,6 @@ struct CodeEditCLI: ParsableCommand {
         defaultSubcommand: Open.self
     )
 
-    init() {}
-
     enum CLIError: Error {
         case invalidWorkingDirectory
         case invalidFileURL


### PR DESCRIPTION
Automatically create a specified file and any necessary parent folders if the provided file path does not exist. 
**Example:**
In an empty folder
`codeedit src/middleware/logger.js`
`tree`
```
.
└── src
    └── middleware
        └── logger.js
```


* closes #32 


https://github.com/CodeEditApp/CodeEditCLI/assets/83090745/5cf160a9-1dd3-4a91-8576-73afed814ef6

